### PR TITLE
Add missing CLIMATE_GRID variables to CORDEX list

### DIFF
--- a/src/valenspy/ancilliary_data/CORDEX_variables.yml
+++ b/src/valenspy/ancilliary_data/CORDEX_variables.yml
@@ -207,19 +207,19 @@ rsdt:
   realm: atmos
   aggregation: a
 
-prhmax: 
+prhmax:
   units: kg m-2 s-1
   standard_name: precipitation_flux
   long_name: Daily Maximum Hourly Precipitation Rate
   realm: atmos
-  aggregation: 
+  aggregation:
 
-sfcWindmax: 
+sfcWindmax:
   units: m s-1
   standard_name: wind_speed
   long_name: Daily Maximum Near-Surface Wind Speed
   realm: atmos
-  aggregation: 
+  aggregation:
 
 
 #################################


### PR DESCRIPTION
Very simple addition of two CORDEX variables. Now all variables of CLIMATE_GRID and EOBS are covered in the .yaml