### PR TITLE
Bugfix era5 inputconvertor: account for valid_time name as time axis

### DIFF
--- a/src/valenspy/inputconverter_functions.py
+++ b/src/valenspy/inputconverter_functions.py
@@ -196,6 +196,9 @@ def ERA5_to_CF(ds: xr.Dataset, metadata_info=None) -> Path:
             if "lat" not in ds[var].coords:
                 ds = ds.rename({"latitude": "lat"})
 
+            # make sure lat and lon are sorted ascending
+            ds = ds.sortby('lat').sortby('lon')
+            
             # bugfix ERA5 (found in clh): replace valid_time by time
             if "time" not in ds: 
                 ds = ds.rename({'valid_time':'time'})


### PR DESCRIPTION
solve #109 by accounting for valid_time as time dimension. Solved by renaming the time dimension. 

Very small fix, can be immediately merged, but out of good practice small review by @kobebryant432 