### PR TITLE
Add manual vmax vmin plotting for bias maps

### DIFF
--- a/src/valenspy/diagnostic_visualizations.py
+++ b/src/valenspy/diagnostic_visualizations.py
@@ -169,7 +169,7 @@ def plot_spatial_bias(da: xr.DataArray, ax=None, region=None, **kwargs):
 
 
 def plot_maps_mod_ref_diff(
-    da_mod: xr.DataArray, da_ref: xr.DataArray, da_diff: xr.DataArray, region=None
+    da_mod: xr.DataArray, da_ref: xr.DataArray, da_diff: xr.DataArray, region=None, **kwargs
 ):
     """
     Plots comparison maps for model data, reference data, and their difference.
@@ -194,7 +194,7 @@ def plot_maps_mod_ref_diff(
 
     """
 
-    # Turn off all warnings
+# Turn off all warnings
     warnings.filterwarnings("ignore")
 
     fig, axes = plt.subplots(
@@ -206,9 +206,15 @@ def plot_maps_mod_ref_diff(
     cbar_label = f"{da_ref.attrs['long_name']} ({da_ref.attrs['units']})"
     cbar_kwargs = {"label": cbar_label}
 
-    # plotting bounds
-    vmin = float(min(da_mod.min().values, da_ref.min().values))
-    vmax = float(max(da_mod.max().values, da_ref.max().values))
+    if "vmin" in kwargs:
+        vmin = kwargs.pop("vmin")
+    else: # plotting boundaries
+        vmin = float(min(da_mod.min().values, da_ref.min().values))
+
+    if "vmax" in kwargs:
+        vmax = kwargs.pop("vmax")
+    else: # plotting boundaries
+        vmax = float(max(da_mod.max().values, da_ref.max().values))
 
     # titles - use the dataset attribute if available
     if "dataset" in da_mod.attrs:
@@ -235,16 +241,30 @@ def plot_maps_mod_ref_diff(
     ax.set_title(ref_title, loc="right")
     _add_features(ax, region=region)
 
+
     # bias
-    ax = axes[2]
     diff_bound = float(max(abs(da_diff.min().values), abs(da_diff.max().values)))
+
+    if "vmin_bias" in kwargs:
+        vmin = kwargs.pop("vmin_bias")
+    else: # plotting boundaries
+        vmin = -diff_bound 
+
+
+    if "vmax_bias" in kwargs:
+        vmax = kwargs.pop("vmax_bias")
+    else: # plotting boundaries
+        vmax = diff_bound 
+
+    ax = axes[2]
     da_diff.plot(
         ax=ax,
         cmap="coolwarm",
-        vmax=diff_bound,
+        vmax=vmax,
         vmin=-diff_bound,
         cbar_kwargs=cbar_kwargs,
     )
+    
     ax.set_title("")
     ax.set_title(f"{mod_title} - {ref_title}", loc="right")
     _add_features(ax, region=region)
@@ -253,6 +273,7 @@ def plot_maps_mod_ref_diff(
     fig.tight_layout()
 
     return axes
+
 
 
 def plot_time_series_mod_ref(


### PR DESCRIPTION
Option to provide hardcoded vmax and vmin to bias maps (plot_maps_mod_ref_diff )  through kwargs, based on request of @fserras299 

Very minor change, tested. 

Very very quick approval @kobebryant432 ?