### PR TITLE
Update to new paths on Hortense

### DIFF
--- a/src/valenspy/ancilliary_data/dataset_PATHS.yml
+++ b/src/valenspy/ancilliary_data/dataset_PATHS.yml
@@ -10,7 +10,7 @@ hortense:
   ERA5:         /dodrio/scratch/projects/2022_200/external/era5/
   ERA5-Land:    /dodrio/scratch/projects/2022_200/external/era5-land/
   EOBS:         /dodrio/scratch/projects/2022_200/external/0.1deg/
-  CLIMATE_GRID: //dodrio/scratch/projects/2022_200/external/climate_grid/
+  CLIMATE_GRID: /dodrio/scratch/projects/2022_200/external/climate_grid/
   shapefiles:   /dodrio/scratch/projects/2022_200/project_output/RMIB-UGent/vsc31332_inne/shapefiles/
   CCLM:         /dodrio/scratch/projects/2022_200/project_output/rcs/CORDEXBE2/postprocessing/
   RADCLIM:      /dodrio/scratch/projects/2022_200/project_output/RMIB-UGent/vsc45263_wout/data/RADCLIM


### PR DESCRIPTION
The obs data has been moved on Hortense following the S4C meeting, so the paths have been adjusted too. 

very minor review, but urgent @kobebryant432 