### PR TITLE
Update to python3.10

### DIFF
--- a/docs/contribution_pages/INSTALL.md
+++ b/docs/contribution_pages/INSTALL.md
@@ -38,7 +38,7 @@ conda config --add envs_dirs /path/to/your/envs
 
 Then create the environment with python and poetry.
 ```bash
-conda create -n valenspy_dev -c conda-forge python==3.9 poetry=1.8
+conda create -n valenspy_dev -c conda-forge python==3.10 poetry=1.8
 source activate valenspy_dev
 ```
 Now install the required packages using poetry: All required packages are listed in the pyproject.toml file and will be installed automatically by poetry.

--- a/docs/contribution_pages/INSTALL_VSC.md
+++ b/docs/contribution_pages/INSTALL_VSC.md
@@ -65,10 +65,10 @@ mkdir -p conda_envs
 conda config --add envs_dirs /dodrio/scratch/projects/2022_200/project_output/__INSTITUTE__/__VSC_USERNAME__/conda_envs
 ```
 
-First initialize the conda environment and install python (version 3.9) and poetry (a python package manager).
+First initialize the conda environment and install python (version 3.10) and poetry (a python package manager).
 
 ```bash
-conda create -n valenspy_dev -c conda-forge python==3.9 poetry=1.8
+conda create -n valenspy_dev -c conda-forge python==3.10 poetry=1.8
 source activate valenspy_dev
 ```
 > [!NOTE]


### PR DESCRIPTION
Closes #155 
Set the standard env to python3.10 instead of python3.9.
Also more manageable with python modules on VSC (I believe).

This has been tested.