### PR TITLE
Diagnostic API improvements

### DIFF
--- a/src/valenspy/diagnostic/diagnostic.py
+++ b/src/valenspy/diagnostic/diagnostic.py
@@ -34,6 +34,10 @@ class Diagnostic:
         self.diagnostic_function = diagnostic_function
         self.plotting_function = plotting_function
 
+    def __call__(self, data, *args, **kwargs):
+        return self.apply(data, *args, **kwargs)
+        
+
     @abstractmethod
     def apply(self, data):
         """Apply the diagnostic to the data.


### PR DESCRIPTION
API improvement to avoid needing to use the .apply when using a diagnostic.
Now it is:
```python
diag = vp.diagnostic.MyFavDiag
ds_result = diag(ds_in, args, kwargs)
````
As apposed to 
```python
diag = vp.diagnostic.MyFavDiag
ds_result = diag.apply(ds_in, args, kwargs)
````